### PR TITLE
Configuração do docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "2.4"
+services:
+  postgres_dev:
+    container_name: "corleone"
+    image: "postgres:13.3-alpine"
+    env_file:
+      - .env
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/data/postgres
+    restart: unless-stopped
+volumes:
+  postgres_data:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "Repositório para desenvolvimento do backend do sistema",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon -w src/server.js --exec \" babel-node src/server.js --presets env \"",
+    "dev": "npm run db:up && npm run babel && npm run db:stop",
+    "babel": "nodemon -w src/server.js --exec \" babel-node src/server.js --presets env \"",
     "build": "babel src -s -D -d dist --presets env",
     "start": "node dist",
+    "db:up": "docker-compose -f docker-compose.yaml up -d",
+    "db:stop": "docker-compose -f docker-compose.yaml stop",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
Resolve a issue #6

O problema estava no arquivo `.env`. Foi necessário colocar as variáveis do banco. O Docker não pega as variáveis de uma string de conexão como já estava lá quando foi criado pelo Prisma. 